### PR TITLE
refactor: avoid using @value annotation to inject config properties

### DIFF
--- a/src/main/java/com/amalitech/usermanagementservice/UserManagementServiceApplication.java
+++ b/src/main/java/com/amalitech/usermanagementservice/UserManagementServiceApplication.java
@@ -1,12 +1,13 @@
 package com.amalitech.usermanagementservice;
 
+import com.amalitech.usermanagementservice.config.properties.EmailPropertiesConfig;
 import com.amalitech.usermanagementservice.config.properties.JwtPropertiesConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties({JwtPropertiesConfig.class})
+@EnableConfigurationProperties({JwtPropertiesConfig.class, EmailPropertiesConfig.class})
 public class UserManagementServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/amalitech/usermanagementservice/config/properties/EmailPropertiesConfig.java
+++ b/src/main/java/com/amalitech/usermanagementservice/config/properties/EmailPropertiesConfig.java
@@ -1,0 +1,14 @@
+package com.amalitech.usermanagementservice.config.properties;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "spring.mail")
+public record EmailPropertiesConfig(
+        @NotBlank String username
+
+) {
+
+}

--- a/src/main/java/com/amalitech/usermanagementservice/services/impl/MailServiceImp.java
+++ b/src/main/java/com/amalitech/usermanagementservice/services/impl/MailServiceImp.java
@@ -1,10 +1,11 @@
 package com.amalitech.usermanagementservice.services.impl;
 
+import com.amalitech.usermanagementservice.config.properties.EmailPropertiesConfig;
 import com.amalitech.usermanagementservice.services.MailService;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -13,16 +14,12 @@ import org.springframework.stereotype.Service;
 import java.io.UnsupportedEncodingException;
 
 @Service
+@RequiredArgsConstructor
 public class MailServiceImp implements MailService {
 
     private final JavaMailSender mailSender;
 
-    @Value("${spring.mail.username}")
-    private String fromEmail;
-    
-    public MailServiceImp(JavaMailSender mailSender) {
-        this.mailSender = mailSender;
-    }
+    private final EmailPropertiesConfig emailPropertiesConfig;
     
     @Override
     public void sendEmail(
@@ -54,7 +51,7 @@ public class MailServiceImp implements MailService {
         helper.setTo(to);
         helper.setSubject(subject);
         helper.setText(htmlBody, true);
-        helper.setFrom(new InternetAddress(fromEmail, "JU Blog"));
+        helper.setFrom(new InternetAddress(emailPropertiesConfig.username(), "JU Blog"));
 
         mailSender.send(message);
     }


### PR DESCRIPTION
- created record class to retrieve configuration props
- added record class to @EnableConfigurationProperties annotation
- updated the config prop field to use the record